### PR TITLE
Improve help screen colors especially under Dark Mode #6

### DIFF
--- a/flutter_app/lib/help_screen.dart
+++ b/flutter_app/lib/help_screen.dart
@@ -37,8 +37,18 @@ class HelpScreen extends StatelessWidget {
           child: FutureBuilder(
             future: loadHelpText(context),
             builder: (context, snapshot) {
+              final Brightness brightnessValue = MediaQuery.of(context).platformBrightness;
+              bool isDark = brightnessValue == Brightness.dark;
               return MarkdownBody(
-                  data: snapshot.data ?? '');
+                data: snapshot.data ?? '',
+                styleSheet: MarkdownStyleSheet.fromTheme(
+                    Theme.of(context)).copyWith(
+                        blockquoteDecoration: BoxDecoration(
+                          color: isDark ? Colors.blue.withOpacity(0.4) : Colors.blue.shade50,
+                          borderRadius: BorderRadius.circular(2.0),
+                      ),
+                    )
+                  );
             },
           ),
         ),


### PR DESCRIPTION
### Description:

The flutter_markdown plugin allows you to pass in a stylesheet. So I pass in a custom styleSheet which is a copy of the global one with a custom blockquoteDecoration property. I also use a mediaQuery on the platformBrightness to determine if in light or dark mode and use that to pass in a custom background color for the markdown blockquotes.

ref: 
https://github.com/flutter/flutter_markdown/blob/master/lib/src/style_sheet.dart
https://medium.com/@pmutisya/dark-mode-in-flutter-3742062f9f59
https://www.xszz.org/faq-6/question-201908285639.html

This pull request resolves #6 

### Testing done:

Viewed help screen on light and dark modes on Simulator (iPhoneX) and Android (Pixel 3). Pixel 3 is a very small phone and these changes did not impact scrollability.